### PR TITLE
Precio repuestos

### DIFF
--- a/src/main/java/GUI/dialogs/JDialogAgregarRepuesto.java
+++ b/src/main/java/GUI/dialogs/JDialogAgregarRepuesto.java
@@ -6,6 +6,8 @@ package GUI.dialogs;
 
 import entities.Repuesto;
 import entities.Stock;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import javax.swing.JOptionPane;
 import org.hibernate.HibernateException;
 import services.RepuestoServ;
@@ -221,7 +223,7 @@ public class JDialogAgregarRepuesto extends javax.swing.JDialog {
         String codBarra = jtfCodBarra.getText().trim();
         String marca = jtfMarca.getText().trim();
         String detalle = jtfDetalle.getText().trim();
-        Double precio = Double.valueOf(jtfPrecio.getText().trim());
+        BigDecimal precio = BigDecimal.valueOf(Double.parseDouble(jtfPrecio.getText().trim())).setScale(2,RoundingMode.HALF_UP);
         Integer cantidad = Integer.valueOf(jtfCantidadStock.getText().trim());
         String ubicacion = jtfUbicacion.getText().trim();
         String lote = jtfLote.getText().trim();

--- a/src/main/java/GUI/dialogs/JDialogEditarRepuesto.java
+++ b/src/main/java/GUI/dialogs/JDialogEditarRepuesto.java
@@ -6,6 +6,8 @@ package GUI.dialogs;
 
 import entities.Repuesto;
 import entities.Stock;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import javax.swing.JOptionPane;
 import org.hibernate.HibernateException;
 import services.RepuestoServ;
@@ -229,7 +231,7 @@ public class JDialogEditarRepuesto extends javax.swing.JDialog {
         String codBarra = jtfCodBarra.getText().trim();
         String marca = jtfMarca.getText().trim();
         String detalle = jtfDetalle.getText().trim();
-        Double precio = Double.valueOf(jtfPrecio.getText().trim());
+        BigDecimal precio = BigDecimal.valueOf(Double.parseDouble(jtfPrecio.getText().trim())).setScale(2,RoundingMode.HALF_UP);
         Integer cantidad = Integer.valueOf(jtfCantidadStock.getText().trim());
         String ubicacion = jtfUbicacion.getText().trim();
         String lote = jtfLote.getText().trim();

--- a/src/main/java/entities/Repuesto.java
+++ b/src/main/java/entities/Repuesto.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.io.Serializable;
+import java.math.BigDecimal;
 
 @Entity
 @Table(name = "repuestos")
@@ -28,8 +29,8 @@ public class Repuesto implements Serializable{
     @Column(nullable = false)
     private String detalle;
 
-    @Column(precision = 2, nullable = false)
-    private Double precio;
+    @Column(precision = 16, scale = 2, nullable = false)
+    private BigDecimal precio;
 
     //RELACIÓN HACIA STOCK 1-1
     @OneToOne(cascade = CascadeType.ALL, optional = false, orphanRemoval = true)
@@ -38,7 +39,7 @@ public class Repuesto implements Serializable{
     public Repuesto() {
     }
 
-    public Repuesto(Long id, String codBarra, String marca, String detalle, Double precio, Stock stock) {
+    public Repuesto(Long id, String codBarra, String marca, String detalle, BigDecimal precio, Stock stock) {
         this.id = id;
         this.codBarra = codBarra;
         this.marca = marca;
@@ -79,11 +80,11 @@ public class Repuesto implements Serializable{
         this.detalle = detalle;
     }
 
-    public Double getPrecio() {
+    public BigDecimal getPrecio() {
         return precio;
     }
 
-    public void setPrecio(Double precio) {
+    public void setPrecio(BigDecimal precio) {
         this.precio = precio;
     }
 


### PR DESCRIPTION
Se cambió el tipo de dato con el que se trabaja los precios de los repuestos para evitar un bug en decimales. No se usa más Double, se usa BigDecimal.